### PR TITLE
Fix reference to GOogle Maps API based changed in recent versions of …

### DIFF
--- a/jma_customizations.module
+++ b/jma_customizations.module
@@ -796,7 +796,7 @@ function geocode($address) {
     $request_url = $config->get('google_maps_base_url');
   }
   else {
-    $request_url = \Drupal\geolocation_google_maps\Plugin\geolocation\MapProvider\GoogleMaps::$GOOGLEMAPSAPIURLBASE;
+    $request_url = \Drupal\geolocation_google_maps\GoogleMapsProviderBase::$googleMapsApiUrlBase;
   }
   $request_url .= '/maps/api/geocode/json?address=' . urlencode($address);
 

--- a/src/Plugin/views/filter/GeolocationProximityViewsFilter.php
+++ b/src/Plugin/views/filter/GeolocationProximityViewsFilter.php
@@ -182,7 +182,7 @@ class GeolocationProximityViewsFilter extends FilterPluginBase implements Contai
   public function geocoder($address) {
     $config = \Drupal::config('geolocation_google_maps.settings');
 
-    $request_url = \Drupal\geolocation_google_maps\Plugin\geolocation\MapProvider\GoogleMaps::$GOOGLEMAPSAPIURLBASE
+    $request_url = \Drupal\geolocation_google_maps\GoogleMapsProviderBase::$googleMapsApiUrlBase
       . '/maps/api/geocode/json?address='
       . urlencode($address)
       . '&key=' . $config->get('google_map_api_key');


### PR DESCRIPTION
…geolocation module needed for D9

@monishdeb this was the other thing I found when I had entered an address into the search on the drupal search it was complaining about no static variable